### PR TITLE
feat/6_i18n

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,5 +64,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'figaro', '~> 1.2'
 gem 'simple_form', '~> 5.1'
+# Help ActiveRecord::Enum feature to work fine with I18n and simple_form.
+gem 'enum_help', '~> 0.0.17'
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.15.3)
     figaro (1.2.0)
@@ -227,6 +229,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  enum_help (~> 0.0.17)
   figaro (~> 1.2)
   foreman (~> 0.87.2)
   jbuilder (~> 2.7)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::Base
+
+  around_action :set_locale
+
+  def set_locale(&action)
+    if params[:language] && I18n.available_locales.include?( params[:language].to_sym )
+      session[:language] = params[:language]
+    end
+
+    I18n.with_locale(session[:language] || I18n.default_locale, &action)
+  end
+
 end

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -14,7 +14,7 @@ class MissionsController < ApplicationController
     @mission = Mission.new(mission_params)
 
     if @mission.save
-      redirect_to root_path, notice: "新增任務成功"
+      redirect_to root_path, notice: t("successfully_create_mission")
     else
       render :new
     end
@@ -28,7 +28,7 @@ class MissionsController < ApplicationController
 
   def update
     if @mission.update(mission_params)
-      redirect_to root_path, notice: "修改任務成功"
+      redirect_to root_path, notice: t("successfully_update_mission")
     else
       render :edit
     end
@@ -36,7 +36,7 @@ class MissionsController < ApplicationController
 
   def destroy
     @mission.delete
-    redirect_to root_path, notice: "刪除任務成功"
+    redirect_to root_path, notice: t("successfully_delete_mission")
   end
 
   private
@@ -47,6 +47,6 @@ class MissionsController < ApplicationController
   def find_mission
     @mission = Mission.find_by(id: params[:id])
   rescue ActiveRecord::RecordNotFound
-    redirect_to root_path, notice: "找不到任務"
+    redirect_to root_path, notice: t("cannot_find_mission")
   end
 end

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -1,6 +1,7 @@
 class Mission < ApplicationRecord
   # belongs_to :user
 
-  enum priorities: { "高": 1, "中": 2, "低": 3 }
+  enum priority: { high: 1, medium: 2, low: 3 }
+  # enum priorities: { "高": 1, "中": 2, "低": 3 }
 
 end

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -1,6 +1,6 @@
 class Mission < ApplicationRecord
   # belongs_to :user
-
+  enum status: { pending: 0, in_progress: 1, done: 2 }
   enum priority: { high: 1, medium: 2, low: 3 }
   # enum priorities: { "高": 1, "中": 2, "低": 3 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,10 @@
   </head>
 
   <body>
+    <nav id="navBar">
+      <%= link_to "中文版", language: "zh-TW" %>
+      <%= link_to "English", language: "en" %>
+    </nav>
     <div id="notice">
       <%= notice %>
     </div>

--- a/app/views/missions/_form.html.erb
+++ b/app/views/missions/_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.input :title, label: t("title") %>
   <%= f.input :content, label: t("content") %>
   <%= f.input :tag, label: t("tag") %>
-  <%= f.input :status, label: t("status"), collection: [t("pending"), t("in_progress"), t("done")] %>
+  <%= f.input :status, label: t("status"), collection: Mission.statuses_i18n %>
   <%= f.input :priority, label: t("priority"), collection: Mission.priorities_i18n %>
   <%= f.input :start_at, label: t("start_at") %>
   <%= f.input :end_at, label: t("end_at") %>

--- a/app/views/missions/_form.html.erb
+++ b/app/views/missions/_form.html.erb
@@ -1,10 +1,10 @@
 <%= simple_form_for(mission) do |f| %>
-  <%= f.input :title, label: "標題" %>
-  <%= f.input :content, label: "內容" %>
-  <%= f.input :tag, label: "標籤" %>
-  <%= f.input :status, label: "狀態", collection: ["待處理", "進行中", "已完成"] %>
-  <%= f.input :priority, label: "優先順序", collection: Mission.priorities %>
-  <%= f.input :start_at, label: "開始時間" %>
-  <%= f.input :end_at, label: "結束時間" %>
+  <%= f.input :title, label: t("title") %>
+  <%= f.input :content, label: t("content") %>
+  <%= f.input :tag, label: t("tag") %>
+  <%= f.input :status, label: t("status"), collection: [t("pending"), t("in_progress"), t("done")] %>
+  <%= f.input :priority, label: t("priority"), collection: Mission.priorities_i18n %>
+  <%= f.input :start_at, label: t("start_at") %>
+  <%= f.input :end_at, label: t("end_at") %>
   <%= f.button :submit %>
 <% end %>

--- a/app/views/missions/edit.html.erb
+++ b/app/views/missions/edit.html.erb
@@ -1,7 +1,7 @@
-<h1>修改任務</h1>
+<h1><%= t("edit_mission") %></h1>
 
 <%= render 'form', mission: @mission %>
 
 <div>
-  <%= link_to "返回任務列表", missions_path %>
+  <%= link_to t("back_to_mission_list"), missions_path %>
 </div>

--- a/app/views/missions/index.html.erb
+++ b/app/views/missions/index.html.erb
@@ -26,7 +26,7 @@
         <td><%= mission.tag %></td>
         <td><%= mission.start_at.strftime("%Y-%m-%d %H:%M") %></td>
         <td><%= mission.end_at.strftime("%Y-%m-%d %H:%M") %></td>
-        <td><%= mission.status %></td>
+        <td><%= mission.status_i18n %></td>
         <td><%= mission.priority_i18n %></td>
         <td><%= link_to t("edit"), edit_mission_path(mission) %></td>
         <td><%= link_to t("delete"), mission_path(mission), method: "delete", data: {confirm: t("confirm_delete")} %></td>

--- a/app/views/missions/index.html.erb
+++ b/app/views/missions/index.html.erb
@@ -1,19 +1,19 @@
-<h1>任務列表</h1>
+<h1><%= t("mission_list") %></h1>
 
 <div>
-  <%= link_to "新增任務",  new_mission_path %>
+  <%= link_to t("new_mission"),  new_mission_path %>
 </div>
 
 <table class="table">
   <thead>
     <tr>
-      <th>作者</th>
-      <th>標題</th>
-      <th>標籤</th>
-      <th>開始時間</th>
-      <th>結束時間</th>
-      <th>狀態</th>
-      <th>優先順序</th>
+      <th><%= t("author") %></th>
+      <th><%= t("title") %></th>
+      <th><%= t("tag") %></th>
+      <th><%= t("start_at") %></th>
+      <th><%= t("end_at") %></th>
+      <th><%= t("status") %></th>
+      <th><%= t("priority") %></th>
       <th></th>
       <th></th>
     </tr>
@@ -24,12 +24,12 @@
         <td></td>
         <td><%= link_to mission.title, mission_path(mission) %></td>
         <td><%= mission.tag %></td>
-        <td><%= mission.start_at %></td>
-        <td><%= mission.end_at %></td>
+        <td><%= mission.start_at.strftime("%Y-%m-%d %H:%M") %></td>
+        <td><%= mission.end_at.strftime("%Y-%m-%d %H:%M") %></td>
         <td><%= mission.status %></td>
-        <td><%= Mission.priorities.key(mission.priority) %></td>
-        <td><%= link_to "編輯", edit_mission_path(mission) %></td>
-        <td><%= link_to "刪除", mission_path(mission), method: "delete", data: {confirm: "是否確定刪除？"} %></td>
+        <td><%= mission.priority_i18n %></td>
+        <td><%= link_to t("edit"), edit_mission_path(mission) %></td>
+        <td><%= link_to t("delete"), mission_path(mission), method: "delete", data: {confirm: t("confirm_delete")} %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/missions/new.html.erb
+++ b/app/views/missions/new.html.erb
@@ -1,7 +1,7 @@
-<h1>新增任務</h1>
+<h1><%= t("new_mission") %></h1>
 
 <%= render 'form', mission: @mission %>
 
 <div>
-  <%= link_to "返回任務列表", missions_path %>
+  <%= link_to t("back_to_mission_list"), missions_path %>
 </div>

--- a/app/views/missions/show.html.erb
+++ b/app/views/missions/show.html.erb
@@ -1,13 +1,17 @@
 <h1><%= @mission.title %></h1>
 
 <ul>
-  <li><%= @mission.tag %></li>
-  <li>狀態：<%= @mission.status %></li>
-  <li>優先順序：<%= Mission.priorities.key(@mission.priority) %></li>
-  <li>開始時間<%= @mission.start_at %></li>
-  <li>結束時間<%= @mission.end_at %></li>
+  <li><%= "#{t("tag")}：#{@mission.tag}" %></li>
+  <li><%= "#{t("status")}：#{@mission.status}" %></li>
+  <li><%= "#{t("priority")}：#{@mission.priority_i18n}" %></li>
+  <li><%= "#{t("start_at")}：#{@mission.start_at.strftime("%Y-%m-%d %H:%M")}" %></li>
+  <li><%= "#{t("end_at")}：#{@mission.end_at.strftime("%Y-%m-%d %H:%M")}" %></li>
 </ul>
 
 <div>
   <%= simple_format(@mission.content) %>
+</div>
+
+<div>
+  <%= link_to t("back_to_mission_list"), missions_path %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,12 +11,15 @@ module EighteenBronzemen
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.i18n.default_locale = "zh-TW"
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Taipei"
+
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ module EighteenBronzemen
     config.load_defaults 6.1
 
     config.i18n.default_locale = "zh-TW"
+    I18n.available_locales = ["en", "zh-TW"]
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,5 +29,223 @@
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.
 
+
+
+
+
+
+# --- #  rails-i18n https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale/
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Validation failed: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    -
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about 1 hour
+        other: about %{count} hours
+      about_x_months:
+        one: about 1 month
+        other: about %{count} months
+      about_x_years:
+        one: about 1 year
+        other: about %{count} years
+      almost_x_years:
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      over_x_years:
+        one: over 1 year
+        other: over %{count} years
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
+      x_years:
+        one: 1 year
+        other: "%{count} years"
+    prompts:
+      second: Second
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
+      year: Year
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: 'Validation failed: %{errors}'
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: 1 error prohibited this %{model} from being saved
+        other: "%{count} errors prohibited this %{model} from being saved"
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,14 +28,40 @@
 #
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.
-
-
-
+en:
+  back_to_mission_list: Back to Mission List
+  mission_list: Mission List
+  new_mission: Create Mission
+  edit_mission: Edit Mission
+  author: Author
+  title: Title
+  tag: Tag
+  start_at: Start From
+  end_at: End At
+  status: Status
+  priority: Priority
+  edit: Edit
+  delete: Delete
+  confirm_delete: Are you sure?
+  content: Content
+  successfully_create_mission: Mission Created Successfully
+  successfully_update_mission: Mission Edited Successfully
+  successfully_delete_mission: Mission Deleted
+  cannot_find_mission: Cannot Find Any Mission
+  enums:
+    mission:
+      priority:
+        high: High
+        medium: Medium
+        low: Low
+      status:
+        pending: Pending
+        in_progress: In Progress
+        done: Done
 
 
 
 # --- #  rails-i18n https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale/
-en:
   activerecord:
     errors:
       messages:

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -1,0 +1,244 @@
+zh-TW:
+  back_to_mission_list: 返回任務列表
+  mission_list: 任務列表
+  new_mission: 新增任務
+  edit_mission: 修改任務
+  author: 作者
+  title: 標題
+  tag: 標籤
+  start_at: 開始時間
+  end_at: 結束時間
+  status: 狀態
+  priority: 優先順序
+  edit: 編輯
+  delete: 刪除
+  confirm_delete: 是否確認刪除?
+  content: 內容
+  pending: 待處理
+  in_progress: 進行中
+  done: 已完成
+  successfully_create_mission: 新增任務成功
+  successfully_update_mission: 修改任務成功
+  successfully_delete_mission: 刪除任務成功
+  cannot_find_mission: 找不到任務
+  enums:
+    mission:
+      priority:
+        high: 高
+        medium: 中
+        low: 低
+
+
+
+# --- #  rails-i18n https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale/
+  activerecord:
+    errors:
+      messages:
+        record_invalid: '校驗失敗: %{errors}'
+        restrict_dependent_destroy:
+          has_one: 由於 %{record} 需要此記錄，所以無法移除記錄
+          has_many: 由於 %{record} 需要此記錄，所以無法移除記錄
+  date:
+    abbr_day_names:
+    - 周日
+    - 周一
+    - 周二
+    - 周三
+    - 周四
+    - 周五
+    - 周六
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 星期日
+    - 星期一
+    - 星期二
+    - 星期三
+    - 星期四
+    - 星期五
+    - 星期六
+    formats:
+      default: "%Y-%m-%d"
+      long: "%Y年%m月%d日"
+      short: "%m月%d日"
+    month_names:
+    -
+    - 一月
+    - 二月
+    - 三月
+    - 四月
+    - 五月
+    - 六月
+    - 七月
+    - 八月
+    - 九月
+    - 十月
+    - 十一月
+    - 十二月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 大約一小時
+        other: 大約 %{count} 小時
+      about_x_months:
+        one: 大約一個月
+        other: 大約 %{count} 個月
+      about_x_years:
+        one: 大約一年
+        other: 大約 %{count} 年
+      almost_x_years:
+        one: 接近一年
+        other: 接近 %{count} 年
+      half_a_minute: 半分鐘
+      less_than_x_seconds:
+        one: 不到一秒
+        other: 不到 %{count} 秒
+      less_than_x_minutes:
+        one: 不到一分鐘
+        other: 不到 %{count} 分鐘
+      over_x_years:
+        one: 一年多
+        other: "%{count} 年多"
+      x_seconds:
+        one: 一秒
+        other: "%{count} 秒"
+      x_minutes:
+        one: 一分鐘
+        other: "%{count} 分鐘"
+      x_days:
+        one: 一天
+        other: "%{count} 天"
+      x_months:
+        one: 一個月
+        other: "%{count} 個月"
+      x_years:
+        one: 一年
+        other: "%{count} 年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: 必須是可被接受的
+      blank: 不能為空白
+      confirmation: 與 %{attribute} 須一致
+      empty: 不能留空
+      equal_to: 必須等於 %{count}
+      even: 必須是偶數
+      exclusion: 是被保留的關鍵字
+      greater_than: 必須大於 %{count}
+      greater_than_or_equal_to: 必須大於或等於 %{count}
+      inclusion: 沒有包含在列表中
+      invalid: 是無效的
+      less_than: 必須小於 %{count}
+      less_than_or_equal_to: 必須小於或等於 %{count}
+      model_invalid: '校驗失敗: %{errors}'
+      not_a_number: 不是數字
+      not_an_integer: 必須是整數
+      odd: 必須是奇數
+      other_than: 不可以是 %{count} 個字
+      present: 必須是空白
+      required: 必須存在
+      taken: 已經被使用
+      too_long:
+        one: 過長（最長是一個字）
+        other: 過長（最長是 %{count} 個字）
+      too_short:
+        one: 過短（最短是一個字）
+        other: 過短（最短是 %{count} 個字）
+      wrong_length:
+        one: 字數錯誤 (必須是一個字)
+        other: 字數錯誤 (必須是 %{count} 個字)
+    template:
+      body: 以下欄位發生問題：
+      header:
+        one: 有 1 個錯誤發生使得「%{model}」無法被儲存。
+        other: 有 %{count} 個錯誤發生使得「%{model}」無法被儲存。
+  helpers:
+    select:
+      prompt: 請選擇
+    submit:
+      create: 新增%{model}
+      submit: 儲存%{model}
+      update: 修改%{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: NT$
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百萬
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: 位元組
+            other: 位元組
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", 和 "
+      two_words_connector: " 和 "
+      words_connector: ", "
+  time:
+    am: 上午
+    formats:
+      default: "%Y年%m月%d日 %A %H:%M:%S %Z"
+      long: "%Y年%m月%d日 %H:%M"
+      short: "%m月%d日 %H:%M"
+    pm: 下午

--- a/config/locales/tw.yml
+++ b/config/locales/tw.yml
@@ -14,9 +14,6 @@ zh-TW:
   delete: 刪除
   confirm_delete: 是否確認刪除?
   content: 內容
-  pending: 待處理
-  in_progress: 進行中
-  done: 已完成
   successfully_create_mission: 新增任務成功
   successfully_update_mission: 修改任務成功
   successfully_delete_mission: 刪除任務成功
@@ -27,6 +24,10 @@ zh-TW:
         high: 高
         medium: 中
         low: 低
+      status:
+        pending: 待處理
+        in_progress: 進行中
+        done: 已完成
 
 
 

--- a/db/migrate/20210626130935_change_status_type.rb
+++ b/db/migrate/20210626130935_change_status_type.rb
@@ -1,0 +1,6 @@
+class ChangeStatusType < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :missions, :status, :string
+    add_column :missions, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_26_031745) do
+ActiveRecord::Schema.define(version: 2021_06_26_130935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,13 +18,13 @@ ActiveRecord::Schema.define(version: 2021_06_26_031745) do
   create_table "missions", force: :cascade do |t|
     t.string "title"
     t.string "tag"
-    t.string "status"
     t.datetime "start_at"
     t.datetime "end_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "priority"
     t.text "content"
+    t.integer "status"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
#6, 步驟9: 將網站中的中文部分共用化
#7, 步驟10: 設定 Rails 的時區

- 新增Gem
  - enum_help, 使設定 enum 的 i18n 時更為簡便
- 將model、view、controller內單詞共用化，寫成 t("variable") 以達成多國語系目的
- 新增切換語言功能 (中文、英文)
- 將時區設為台北